### PR TITLE
test: use Serilog.Sinks.InMemory

### DIFF
--- a/test/Cnblogs.Architecture.IntegrationTestProject/Constants.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Constants.cs
@@ -4,4 +4,9 @@ public static class Constants
 {
     public const string AppName = "test-web";
     public const string IntegrationEventIdHeaderName = "X-IntegrationEvent-Id";
+
+    public static class LogTemplates
+    {
+        public const string HandledIntegratonEvent = "Handled integration event {@event}.";
+    }
 }

--- a/test/Cnblogs.Architecture.IntegrationTestProject/EventHandlers/TestIntegrationEventHandler.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/EventHandlers/TestIntegrationEventHandler.cs
@@ -1,29 +1,21 @@
 ﻿using Cnblogs.Architecture.Ddd.EventBus.Abstractions;
 using Cnblogs.Architecture.TestIntegrationEvents;
+using static Cnblogs.Architecture.IntegrationTestProject.Constants;
 
 namespace Cnblogs.Architecture.IntegrationTestProject.EventHandlers;
 
 public class TestIntegrationEventHandler : IIntegrationEventHandler<TestIntegrationEvent>
 {
-    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger _logger;
 
-    public TestIntegrationEventHandler(IHttpContextAccessor httpContextAccessor, ILogger<TestIntegrationEventHandler> logger)
+    public TestIntegrationEventHandler(ILogger<TestIntegrationEventHandler> logger)
     {
-        _httpContextAccessor = httpContextAccessor;
         _logger = logger;
     }
 
     public Task Handle(TestIntegrationEvent notification, CancellationToken cancellationToken)
     {
-        var context = _httpContextAccessor.HttpContext;
-        context?.Response.OnStarting(() =>
-        {
-            context.Response.Headers.Add(Constants.IntegrationEventIdHeaderName, notification.Id.ToString());
-            return Task.CompletedTask;
-        });
-
-        _logger.LogInformation("Handled integration event {event}.", notification);
+        _logger.LogInformation(LogTemplates.HandledIntegratonEvent, notification);
 
         return Task.CompletedTask;
     }

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Program.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Program.cs
@@ -17,7 +17,6 @@ builder.Services.AddControllers().AddCqrsModelBinderProvider();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddCnblogsApiVersioning();
 builder.Services.AddSwaggerGen();
-builder.Services.AddHttpContextAccessor();
 
 var app = builder.Build();
 

--- a/test/Cnblogs.Architecture.IntegrationTests/Cnblogs.Architecture.IntegrationTests.csproj
+++ b/test/Cnblogs.Architecture.IntegrationTests/Cnblogs.Architecture.IntegrationTests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Cnblogs.Serilog.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -20,6 +21,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Cnblogs.Architecture.IntegrationTestProject\Cnblogs.Architecture.IntegrationTestProject.csproj" />
     <ProjectReference Include="..\Cnblogs.Architecture.TestShared\Cnblogs.Architecture.TestShared.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
+    <PackageReference Include="Serilog.Sinks.InMemory.Assertions" Version="0.11.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Use Serilog.Sinks.InMemory to assert an integration event has been handled.