### PR TITLE
fix: remove redundant double quote when command fails

### DIFF
--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/ApiControllerBase.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/ApiControllerBase.cs
@@ -60,4 +60,14 @@ public class ApiControllerBase : ControllerBase
 
         return BadRequest(response.ErrorCode?.Name ?? response.ErrorMessage);
     }
+
+    private static IActionResult BadRequest(string text)
+    {
+        return new ContentResult
+        {
+            Content = text,
+            ContentType = "text/plain",
+            StatusCode = 400
+        };
+    }
 }

--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CommandEndpointHandler.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CommandEndpointHandler.cs
@@ -61,7 +61,7 @@ public class CommandEndpointHandler : IEndpointFilter
     {
         if (response.IsValidationError)
         {
-            return Results.BadRequest(response.ValidationError!.Message);
+            return Results.Text(response.ValidationError!.Message, statusCode: 400);
         }
 
         if (response is { IsConcurrentError: true, LockAcquired: false })
@@ -69,6 +69,6 @@ public class CommandEndpointHandler : IEndpointFilter
             return Results.StatusCode(429);
         }
 
-        return Results.BadRequest(response.GetErrorMessage());
+        return Results.Text(response.GetErrorMessage(), statusCode: 400);
     }
 }

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Controllers/TestController.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Controllers/TestController.cs
@@ -1,5 +1,5 @@
 ﻿using Asp.Versioning;
-
+using Cnblogs.Architecture.Ddd.Cqrs.AspNetCore;
 using Cnblogs.Architecture.Ddd.Infrastructure.Abstractions;
 
 using Microsoft.AspNetCore.Mvc;
@@ -7,9 +7,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace Cnblogs.Architecture.IntegrationTestProject.Controllers;
 
 [ApiVersion("1")]
-[ApiController]
 [Route("/api/v{version:apiVersion}")]
-public class TestController : ControllerBase
+public class TestController : ApiControllerBase
 {
     [HttpGet("paging")]
     public Task<PagingParams?> PagingParamsAsync([FromQuery] PagingParams? pagingParams)

--- a/test/Cnblogs.Architecture.IntegrationTests/CommandResponseHandlerTests.cs
+++ b/test/Cnblogs.Architecture.IntegrationTests/CommandResponseHandlerTests.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+using Cnblogs.Architecture.IntegrationTestProject;
+using Cnblogs.Architecture.IntegrationTestProject.Application.Errors;
+using Cnblogs.Architecture.IntegrationTestProject.Payloads;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Cnblogs.Architecture.IntegrationTests;
+
+public class CommandResponseHandlerTests
+{
+    [Fact]
+    public async Task HandleCommandResponse_HavingError_BadRequestAsync()
+    {
+        // Arrange
+        var builder = new WebApplicationFactory<Program>();
+
+        // Act
+        var response = await builder.CreateClient().PutAsJsonAsync("/api/v1/strings/1", new UpdatePayload(true));
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.Should().HaveClientError();
+        content.Should().Be(TestError.Default.Name);
+    }
+
+    [Fact]
+    public async Task HandleCommandResponse_Success_OkAsync()
+    {
+        // Arrange
+        var builder = new WebApplicationFactory<Program>();
+
+        // Act
+        var response = await builder.CreateClient().PutAsJsonAsync("/api/v1/strings/1", new UpdatePayload(false));
+
+        // Assert
+        response.Should().BeSuccessful();
+    }
+}


### PR DESCRIPTION
Fixes #65 