### PR TITLE
feat: add long to string json converter

### DIFF
--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/ControllerOptionInjector.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/ControllerOptionInjector.cs
@@ -23,8 +23,17 @@ public static class ControllerOptionInjector
     ///     Add custom model binder used for CQRS, like model binder for <see cref="PagingParams"/>.
     /// </summary>
     /// <param name="builder"><see cref="IMvcBuilder"/></param>
-    public static void AddCqrsModelBinderProvider(this IMvcBuilder builder)
+    public static IMvcBuilder AddCqrsModelBinderProvider(this IMvcBuilder builder)
     {
-        builder.AddMvcOptions(options => options.AddCqrsModelBinderProvider());
+        return builder.AddMvcOptions(options => options.AddCqrsModelBinderProvider());
+    }
+
+    /// <summary>
+    ///     Add long to string json converter.
+    /// </summary>
+    /// <param name="builder"><see cref="IMvcBuilder"/>.</param>
+    public static IMvcBuilder AddLongToStringJsonConverter(this IMvcBuilder builder)
+    {
+        return builder.AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(new LongToStringConverter()));
     }
 }

--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsHttpOptions.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsHttpOptions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Cnblogs.Architecture.Ddd.Cqrs.Abstractions;
 using Microsoft.AspNetCore.Http;
 
@@ -17,4 +18,12 @@ public class CqrsHttpOptions
     ///     Custom logic to handle error command response.
     /// </summary>
     public Func<CommandResponse, HttpContext, IResult>? CustomCommandErrorResponseMapper { get; set; }
+
+    /// <summary>
+    ///     Default json serializer options for minimal api.
+    /// </summary>
+    /// <remarks>
+    ///     For Controllers, please use <c>builder.AddControllers().AddLongToStringJsonConverter();</c>
+    /// </remarks>
+    public JsonSerializerOptions DefaultJsonSerializerOptions { get; set; } = new(JsonSerializerDefaults.Web);
 }

--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsHttpOptionsInjector.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsHttpOptionsInjector.cs
@@ -48,7 +48,7 @@ public static class CqrsHttpOptionsInjector
     /// </summary>
     /// <param name="injector"></param>
     /// <returns></returns>
-    public static CqrsInjector UseLongToStringJsonConverter(this CqrsInjector injector)
+    public static CqrsInjector AddLongToStringJsonConverter(this CqrsInjector injector)
     {
         injector.Services.Configure<CqrsHttpOptions>(
             o => o.DefaultJsonSerializerOptions.Converters.Add(new LongToStringConverter()));

--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsHttpOptionsInjector.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsHttpOptionsInjector.cs
@@ -42,4 +42,16 @@ public static class CqrsHttpOptionsInjector
             });
         return injector;
     }
+
+    /// <summary>
+    ///     Serialize long to string for all json output.
+    /// </summary>
+    /// <param name="injector"></param>
+    /// <returns></returns>
+    public static CqrsInjector UseLongToStringJsonConverter(this CqrsInjector injector)
+    {
+        injector.Services.Configure<CqrsHttpOptions>(
+            o => o.DefaultJsonSerializerOptions.Converters.Add(new LongToStringConverter()));
+        return injector;
+    }
 }

--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsResult.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsResult.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 
 namespace Cnblogs.Architecture.Ddd.Cqrs.AspNetCore;
 
@@ -6,12 +7,12 @@ namespace Cnblogs.Architecture.Ddd.Cqrs.AspNetCore;
 ///     Send object as json and append X-Cqrs-Version header
 /// </summary>
 /// <param name="commandResponse"></param>
-public class CqrsResult(object commandResponse) : IResult
+public class CqrsResult(object commandResponse, JsonSerializerOptions? options = null) : IResult
 {
     /// <inheritdoc />
     public Task ExecuteAsync(HttpContext httpContext)
     {
         httpContext.Response.Headers.Append("X-Cqrs-Version", "2");
-        return httpContext.Response.WriteAsJsonAsync(commandResponse);
+        return httpContext.Response.WriteAsJsonAsync(commandResponse, options);
     }
 }

--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsResultExtensions.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/CqrsResultExtensions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 
 namespace Cnblogs.Architecture.Ddd.Cqrs.AspNetCore;
@@ -12,10 +13,11 @@ public static class CqrsResultExtensions
     /// </summary>
     /// <param name="extensions"><see cref="IResultExtensions"/></param>
     /// <param name="result">The command response.</param>
+    /// <param name="options">Optional json serializer options.</param>
     /// <returns></returns>
-    public static IResult Cqrs(this IResultExtensions extensions, object result)
+    public static IResult Cqrs(this IResultExtensions extensions, object result, JsonSerializerOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(extensions);
-        return new CqrsResult(result);
+        return new CqrsResult(result, options);
     }
 }

--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/LongToStringConverter.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/LongToStringConverter.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cnblogs.Architecture.Ddd.Cqrs.AspNetCore;
+
+/// <summary>
+/// Converter between long and string
+/// </summary>
+internal class LongToStringConverter : JsonConverter<long>
+{
+    /// <inheritdoc />
+    public override long Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            return reader.GetInt64();
+        }
+
+        var raw = reader.GetString();
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new JsonException("string is empty");
+        }
+
+        var success = long.TryParse(raw, out var parsed);
+        if (success == false)
+        {
+            throw new JsonException("string value can't be converted to long");
+        }
+
+        return parsed;
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, long value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}

--- a/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/QueryEndpointHandler.cs
+++ b/src/Cnblogs.Architecture.Ddd.Cqrs.AspNetCore/QueryEndpointHandler.cs
@@ -1,25 +1,14 @@
 ﻿using MediatR;
-
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Cnblogs.Architecture.Ddd.Cqrs.AspNetCore;
 
 /// <summary>
 ///     The query executor, auto send query to <see cref="IMediator"/>.
 /// </summary>
-public class QueryEndpointHandler : IEndpointFilter
+public class QueryEndpointHandler(IMediator mediator, IOptions<CqrsHttpOptions> cqrsHttpOptions) : IEndpointFilter
 {
-    private readonly IMediator _mediator;
-
-    /// <summary>
-    ///     Create a <see cref="QueryEndpointHandler"/>.
-    /// </summary>
-    /// <param name="mediator">The mediator to use.</param>
-    public QueryEndpointHandler(IMediator mediator)
-    {
-        _mediator = mediator;
-    }
-
     /// <inheritdoc />
     public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
     {
@@ -34,7 +23,9 @@ public class QueryEndpointHandler : IEndpointFilter
             return query;
         }
 
-        var response = await _mediator.Send(query);
-        return response == null ? Results.NotFound() : Results.Ok(response);
+        var response = await mediator.Send(query);
+        return response == null
+            ? Results.NotFound()
+            : Results.Json(response, cqrsHttpOptions.Value.DefaultJsonSerializerOptions);
     }
 }

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Application/Commands/CreateLongToStringCommand.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Application/Commands/CreateLongToStringCommand.cs
@@ -1,0 +1,7 @@
+using Cnblogs.Architecture.Ddd.Cqrs.Abstractions;
+using Cnblogs.Architecture.IntegrationTestProject.Application.Errors;
+using Cnblogs.Architecture.IntegrationTestProject.Models;
+
+namespace Cnblogs.Architecture.IntegrationTestProject.Application.Commands;
+
+public record CreateLongToStringCommand(long Id, bool ValidateOnly = false) : ICommand<LongToStringModel, TestError>;

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Application/Commands/CreateLongToStringCommandHandler.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Application/Commands/CreateLongToStringCommandHandler.cs
@@ -1,0 +1,16 @@
+using Cnblogs.Architecture.Ddd.Cqrs.Abstractions;
+using Cnblogs.Architecture.IntegrationTestProject.Application.Errors;
+using Cnblogs.Architecture.IntegrationTestProject.Models;
+
+namespace Cnblogs.Architecture.IntegrationTestProject.Application.Commands;
+
+public class CreateLongToStringCommandHandler : ICommandHandler<CreateLongToStringCommand, LongToStringModel, TestError>
+{
+    /// <inheritdoc />
+    public async Task<CommandResponse<LongToStringModel, TestError>> Handle(
+        CreateLongToStringCommand request,
+        CancellationToken cancellationToken)
+    {
+        return CommandResponse<LongToStringModel, TestError>.Success(new LongToStringModel() { Id = request.Id });
+    }
+}

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Application/Commands/CreateLongToStringCommandHandler.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Application/Commands/CreateLongToStringCommandHandler.cs
@@ -7,10 +7,10 @@ namespace Cnblogs.Architecture.IntegrationTestProject.Application.Commands;
 public class CreateLongToStringCommandHandler : ICommandHandler<CreateLongToStringCommand, LongToStringModel, TestError>
 {
     /// <inheritdoc />
-    public async Task<CommandResponse<LongToStringModel, TestError>> Handle(
+    public Task<CommandResponse<LongToStringModel, TestError>> Handle(
         CreateLongToStringCommand request,
         CancellationToken cancellationToken)
     {
-        return CommandResponse<LongToStringModel, TestError>.Success(new LongToStringModel() { Id = request.Id });
+        return Task.FromResult(CommandResponse<LongToStringModel, TestError>.Success(new LongToStringModel() { Id = request.Id }));
     }
 }

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Application/Queries/GetLongToStringQuery.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Application/Queries/GetLongToStringQuery.cs
@@ -1,0 +1,6 @@
+using Cnblogs.Architecture.Ddd.Cqrs.Abstractions;
+using Cnblogs.Architecture.IntegrationTestProject.Models;
+
+namespace Cnblogs.Architecture.IntegrationTestProject.Application.Queries;
+
+public record GetLongToStringQuery(long Id) : IQuery<LongToStringModel>;

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Application/Queries/GetLongToStringQueryHandler.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Application/Queries/GetLongToStringQueryHandler.cs
@@ -1,0 +1,13 @@
+using Cnblogs.Architecture.Ddd.Cqrs.Abstractions;
+using Cnblogs.Architecture.IntegrationTestProject.Models;
+
+namespace Cnblogs.Architecture.IntegrationTestProject.Application.Queries;
+
+public class GetLongToStringQueryHandler : IQueryHandler<GetLongToStringQuery, LongToStringModel>
+{
+    /// <inheritdoc />
+    public async Task<LongToStringModel?> Handle(GetLongToStringQuery request, CancellationToken cancellationToken)
+    {
+        return new LongToStringModel() { Id = request.Id };
+    }
+}

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Application/Queries/GetLongToStringQueryHandler.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Application/Queries/GetLongToStringQueryHandler.cs
@@ -6,8 +6,8 @@ namespace Cnblogs.Architecture.IntegrationTestProject.Application.Queries;
 public class GetLongToStringQueryHandler : IQueryHandler<GetLongToStringQuery, LongToStringModel>
 {
     /// <inheritdoc />
-    public async Task<LongToStringModel?> Handle(GetLongToStringQuery request, CancellationToken cancellationToken)
+    public Task<LongToStringModel?> Handle(GetLongToStringQuery request, CancellationToken cancellationToken)
     {
-        return new LongToStringModel() { Id = request.Id };
+        return Task.FromResult((LongToStringModel?)new LongToStringModel() { Id = request.Id });
     }
 }

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Controllers/TestController.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Controllers/TestController.cs
@@ -2,6 +2,8 @@
 using Cnblogs.Architecture.Ddd.Cqrs.AspNetCore;
 using Cnblogs.Architecture.Ddd.Infrastructure.Abstractions;
 using Cnblogs.Architecture.IntegrationTestProject.Application.Commands;
+using Cnblogs.Architecture.IntegrationTestProject.Application.Queries;
+using Cnblogs.Architecture.IntegrationTestProject.Models;
 using Cnblogs.Architecture.IntegrationTestProject.Payloads;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -10,15 +12,8 @@ namespace Cnblogs.Architecture.IntegrationTestProject.Controllers;
 
 [ApiVersion("1")]
 [Route("/api/v{version:apiVersion}/mvc")]
-public class TestController : ApiControllerBase
+public class TestController(IMediator mediator) : ApiControllerBase
 {
-    private readonly IMediator _mediator;
-
-    public TestController(IMediator mediator)
-    {
-        _mediator = mediator;
-    }
-
     [HttpGet("paging")]
     public Task<PagingParams?> PagingParamsAsync([FromQuery] PagingParams? pagingParams)
     {
@@ -29,7 +24,20 @@ public class TestController : ApiControllerBase
     public async Task<IActionResult> PutStringAsync(int id, [FromBody] UpdatePayload payload)
     {
         var response =
-            await _mediator.Send(new UpdateCommand(id, payload.NeedValidationError, payload.NeedExecutionError));
+            await mediator.Send(new UpdateCommand(id, payload.NeedValidationError, payload.NeedExecutionError));
+        return HandleCommandResponse(response);
+    }
+
+    [HttpGet("json/long-to-string/{id:long}")]
+    public async Task<LongToStringModel?> GetLongToStringModelAsync(long id)
+    {
+        return await mediator.Send(new GetLongToStringQuery(id));
+    }
+
+    [HttpPost("json/long-to-string")]
+    public async Task<IActionResult> CreateLongToStringModelAsync([FromBody] LongToStringModel model)
+    {
+        var response = await mediator.Send(new CreateLongToStringCommand(model.Id));
         return HandleCommandResponse(response);
     }
 }

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Models/LongToStringModel.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Models/LongToStringModel.cs
@@ -1,0 +1,6 @@
+namespace Cnblogs.Architecture.IntegrationTestProject.Models;
+
+public class LongToStringModel
+{
+    public long Id { get; set; }
+}

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Program.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Program.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddCqrs(Assembly.GetExecutingAssembly(), typeof(TestIntegrationEvent).Assembly)
-    .UseLongToStringJsonConverter()
+    .AddLongToStringJsonConverter()
     .AddDefaultDateTimeAndRandomProvider()
     .AddEventBus(o => o.UseDapr(Constants.AppName));
 builder.Services.AddControllers().AddCqrsModelBinderProvider().AddLongToStringJsonConverter();

--- a/test/Cnblogs.Architecture.IntegrationTestProject/Program.cs
+++ b/test/Cnblogs.Architecture.IntegrationTestProject/Program.cs
@@ -12,9 +12,10 @@ using Microsoft.AspNetCore.Mvc;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddCqrs(Assembly.GetExecutingAssembly(), typeof(TestIntegrationEvent).Assembly)
+    .UseLongToStringJsonConverter()
     .AddDefaultDateTimeAndRandomProvider()
     .AddEventBus(o => o.UseDapr(Constants.AppName));
-builder.Services.AddControllers().AddCqrsModelBinderProvider();
+builder.Services.AddControllers().AddCqrsModelBinderProvider().AddLongToStringJsonConverter();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddCnblogsApiVersioning();
@@ -46,6 +47,8 @@ v1.MapQuery(
     async (int stringId, [FromQuery] bool found = true)
         => await Task.FromResult(new GetStringQuery(StringId: stringId, Found: found)));
 v1.MapQuery<ListStringsQuery>("strings");
+v1.MapQuery<GetLongToStringQuery>("long-to-string/{id:long}");
+v1.MapCommand<CreateLongToStringCommand>("long-to-string");
 v1.MapCommand(
     "strings",
     (CreatePayload payload) => Task.FromResult(new CreateCommand(payload.NeedError, payload.Data)));

--- a/test/Cnblogs.Architecture.IntegrationTests/CustomJsonConverterTests.cs
+++ b/test/Cnblogs.Architecture.IntegrationTests/CustomJsonConverterTests.cs
@@ -1,0 +1,96 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Cnblogs.Architecture.IntegrationTestProject;
+using Cnblogs.Architecture.IntegrationTestProject.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Cnblogs.Architecture.IntegrationTests;
+
+public class CustomJsonConverterTests
+{
+    private static readonly JsonSerializerOptions WebDefaults = new(JsonSerializerDefaults.Web);
+
+    [Theory]
+    [InlineData("/api/v1/mvc/json/long-to-string/")]
+    [InlineData("/api/v1/long-to-string/")]
+    public async Task LongToJson_WriteLongToString_CanBeParsedByServerAsync(string baseUrl)
+    {
+        // Arrange
+        const long id = 202410267558024668;
+        var builder = new WebApplicationFactory<Program>();
+
+        // Act
+        var response = await builder.CreateClient().GetAsync(baseUrl + id);
+        var serverObject = await response.Content.ReadFromJsonAsync<LongToStringModel>(WebDefaults);
+
+        // Assert
+        serverObject.Should().BeEquivalentTo(new LongToStringModel() { Id = id });
+    }
+
+    [Theory]
+    [InlineData("/api/v1/mvc/json/long-to-string/")]
+    [InlineData("/api/v1/long-to-string/")]
+    public async Task LongToJson_WriteLongToString_IsStringInJsonAsync(string baseUrl)
+    {
+        // Arrange
+        const long id = 202410267558024668;
+        var builder = new WebApplicationFactory<Program>();
+
+        // Act
+        var response = await builder.CreateClient().GetAsync(baseUrl + id);
+        var browserObject = await response.Content.ReadFromJsonAsync<JsonElement>(WebDefaults);
+
+        // Assert
+        browserObject.EnumerateObject().First().Value.GetString().Should().Be(id.ToString());
+    }
+
+    [Theory]
+    [InlineData("/api/v1/mvc/json/long-to-string/")]
+    [InlineData("/api/v1/long-to-string/")]
+    public async Task LongToJson_ReadLongFromString_SuccessAsync(string url)
+    {
+        // Arrange
+        const string json = """
+                            {
+                                "id": "202410267558024668"
+                            }
+                            """;
+
+        var builder = new WebApplicationFactory<Program>();
+
+        // Act
+        var response = await builder.CreateClient().PostAsync(
+            url,
+            new StringContent(json, Encoding.UTF8, "application/json"));
+        var model = await response.Content.ReadFromJsonAsync<JsonElement>(WebDefaults);
+
+        // Assert
+        model.EnumerateObject().First().Value.GetString().Should().Be("202410267558024668");
+    }
+
+    [Theory]
+    [InlineData("/api/v1/mvc/json/long-to-string/")]
+    [InlineData("/api/v1/long-to-string/")]
+    public async Task LongToJson_ReadLongFromNumber_SuccessAsync(string url)
+    {
+        // Arrange
+        const string json = """
+                            {
+                                "id": 202410267558024668
+                            }
+                            """;
+
+        var builder = new WebApplicationFactory<Program>();
+
+        // Act
+        var response = await builder.CreateClient().PostAsync(
+            url,
+            new StringContent(json, Encoding.UTF8, "application/json"));
+        var model = await response.Content.ReadFromJsonAsync<JsonElement>(WebDefaults);
+
+        // Assert
+        model.EnumerateObject().First().Value.GetString().Should().Be("202410267558024668");
+    }
+}


### PR DESCRIPTION
Add custom converter that converts `long` to `string` for browser(javascript) compatibility.

**Usage**

Minimal Api

```cs
builder.AddCqrs().AddLongToStringJsonConverter();
```

Mvc

```cs
builder.AddControllers().AddLongToStringJsonConverter();
```